### PR TITLE
ci: fix PyPI publish

### DIFF
--- a/patches/setup.patch
+++ b/patches/setup.patch
@@ -1,12 +1,20 @@
 diff --git a/setup.py b/setup.py
-index fb50e2e..2e3b9ea 100644
+index fb50e2e..56fb381 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -28,14 +28,15 @@ setup(
+@@ -23,19 +23,20 @@ with open('requirements.txt') as handle:
+     requirements = [str(req) for req in parse_requirements(handle)]
+ 
+ setup(
+-    name='PlexAPI',
++    name='PlexAPI-backport',
+     version=version['__version__'],
      description='Python bindings for the Plex API.',
-     author='Michael Shepanski',
-     author_email='michael.shepanski@gmail.com',
+-    author='Michael Shepanski',
+-    author_email='michael.shepanski@gmail.com',
 -    url='https://github.com/pkkid/python-plexapi',
++    author='LizardByte',
++    author_email='LizardByte@ithub.com',
 +    url='https://github.com/LizardByte/python-plexapi-backport',
      packages=['plexapi'],
      install_requires=requirements,


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Use `PlexAPI-backport` as name in `setup.py` to Fix PyPI publish step.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
