### PR TITLE
ci: override branch for codecov reports on push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,6 +468,14 @@ jobs:
         with:
           flags: Plex-${{ matrix.plex }},Python-${{ matrix.python }}
 
+      # due to running pytest on a patched version, the code lines will not match without overriding the branch
+      - name: Upload ${{ matrix.plex }} coverage to Codecov (dist)
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/master')
+        uses: codecov/codecov-action@v3
+        with:
+          flags: Plex-${{ matrix.plex }},Python-${{ matrix.python }}
+          override_branch: dist
+
   publish:
     name: Publish
     if: >-


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
We are unable to view the coverage lines since we are running tests against a patched version of plexapi... so this uploads the coverage artifacts as the `dist` branch, where applicable.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
