### PR TITLE
fix: do not use future.standard_library.install_aliases()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,33 +90,31 @@ jobs:
             echo "Applying pasteurize to ${file}"
             # -x arg is not working, need to specify each fix to include
             pasteurize -j $(nproc) --verbose --write --nobackups \
-              -f libfuturize.fixes.fix_future_standard_library \
               -f libpasteurize.fixes.fix_add_all__future__imports \
-              -f libpasteurize.fixes.fix_add_future_standard_library_import \
               -f libpasteurize.fixes.fix_annotations \
               -f libpasteurize.fixes.fix_division \
               -f libpasteurize.fixes.fix_fullargspec \
               -f libpasteurize.fixes.fix_future_builtins \
-              -f libpasteurize.fixes.fix_imports \
-              -f libpasteurize.fixes.fix_imports2 \
               -f libpasteurize.fixes.fix_kwargs \
               -f libpasteurize.fixes.fix_newstyle \
-              -f libpasteurize.fixes.fix_printfunction \
               -f libpasteurize.fixes.fix_throw \
               -f libpasteurize.fixes.fix_unpacking \
               ${file}
 
-            # -f libfuturize.fixes.fix_future_standard_library \  # tbd
+            # -f libfuturize.fixes.fix_future_standard_library \  # does some install_aliases()
+
             # adds absolute import, division, print_function, unicode_literals
             # -f libpasteurize.fixes.fix_add_all__future__imports \
+
             # from future import standard_library... install_aliases()
             # -f libpasteurize.fixes.fix_add_future_standard_library_import \
+
             # -f libpasteurize.fixes.fix_annotations \  # tbd
             # -f libpasteurize.fixes.fix_division \  # division is different in Python 3
             # -f libpasteurize.fixes.fix_fullargspec \  # tbd
             # -f libpasteurize.fixes.fix_future_builtins \  # from builtins import next, round, int, str, super, etc.
             # -f libpasteurize.fixes.fix_getcwd  \  # replaces os.getcwd with os.getcwdu (unicode version)
-            # -f libpasteurize.fixes.fix_imports \  # tbd
+            # -f libpasteurize.fixes.fix_imports \  # does some install_aliases()
             # -f libpasteurize.fixes.fix_imports2 \  # from future import standard_library... install_aliases()
             # -f libpasteurize.fixes.fix_kwargs \  # tbd
             # -f libpasteurize.fixes.fix_newstyle \  # tbd
@@ -125,10 +123,16 @@ jobs:
             # -f libpasteurize.fixes.fix_unpacking \  # tbd
 
             # excluding these fixes
+            # libfuturize.fixes.fix_future_standard_library  # do not want to install_aliases()
+            # libpasteurize.fixes.fix_add_future_standard_library_import  # do not want to install_aliases()
             # libpasteurize.fixes.fix_getcwd  # cwd probably doesn't need to be unicode
+            # libpasteurize.fixes.fix_imports  # do not want to install_aliases()
+            # libpasteurize.fixes.fix_imports2  # do not want to install_aliases()
+            # libpasteurize.fixes.fix_printfunction  # print in Python 3 is okay in Python 2.7.
 
             # remove `from __future__ import unicode_literals` from each file
             echo "Removing unwanted __future__ imports from ${file}"
+            sed -i '/from __future__ import print_function/d' ${file}
             sed -i '/from __future__ import unicode_literals/d' ${file}
 
             echo "Removing unwanted from builtin imports from ${file}"

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Python-PlexAPI-Backport
 .. image:: https://img.shields.io/readthedocs/python-plexapi-backport?label=Docs&style=for-the-badge&logo=readthedocs
    :alt: Read the Docs
    :target: http://python-plexapi-backport.readthedocs.io/
-.. image:: https://img.shields.io/codecov/c/github/LizardByte/python-plexapi-backport?flag=Python-2.7&style=for-the-badge&logo=codecov&label=codecov
+.. image:: https://img.shields.io/codecov/c/gh/LizardByte/python-plexapi-backport?token=6YMJYJPCRN&flag=Python-2.7&style=for-the-badge&logo=codecov&label=codecov
    :alt: Codecov
    :target: https://codecov.io/gh/LizardByte/python-plexapi-backport
 .. image:: https://img.shields.io/pypi/v/PlexAPI-backport.svg?style=for-the-badge&logo=pypi&label=pypi%20package

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+---
 codecov:
   branch: dist
 

--- a/custom_patches.py
+++ b/custom_patches.py
@@ -351,6 +351,37 @@ def super_patch(lines):
     return output_lines
 
 
+def urllib_imports_patch(lines):
+    # type: (List[str]) -> List[str]
+    """
+    Patch urllib imports to be compatible with Python 2.7.
+
+    If the file contains `from urllib.parse import`, then this function will replace it with
+    `from six.moves.urllib.parse import`.
+
+    Parameters
+    ----------
+    lines
+        The lines of the file.
+
+    Returns
+    -------
+    List[str]
+        Updated lines.
+    """
+    patched_lines = []
+
+    for line in lines:
+        if 'from urllib.parse import' in line:
+            # Just replace the original module path with six.moves
+            new_import_line = line.replace('from urllib.parse', 'from six.moves.urllib.parse')
+            patched_lines.append(new_import_line)
+        else:
+            patched_lines.append(line)
+
+    return patched_lines
+
+
 def yield_from_patch(lines):
     # type: (List[str]) -> List[str]
     """
@@ -419,6 +450,7 @@ def process_file(file_path):
     lines = arg_unpack_patch(lines=lines)
     lines = raise_from_none_patch(lines=lines)
     lines = super_patch(lines=lines)
+    lines = urllib_imports_patch(lines=lines)
     lines = yield_from_patch(lines=lines)
 
     # these are last because they mess with indentation of imports

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ configparser==4.0.2;python_version<"3"
 future==0.18.3  # needed for all versions since patched setup.py uses it
 pathlib2==2.3.7.post1;python_version<"3.4"
 requests==2.27.1;python_version<"3"
+six==1.16.0
 typing;python_version<"3.5"
 qualname==0.1.0;python_version<"3.3"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Do not use install_aliases() function as it globally modifies the behavior of the Python interpreter, which can cause issues with other modules.

Based on findings in https://github.com/ytdl-org/youtube-dl/issues/32544


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
