### PR TITLE
ci: add build number to pypi builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,8 @@ jobs:
           python -m pip install --upgrade -r requirements_dev.txt
 
       - name: build
+        env:
+          BUILD_VERSION: ${{ github.run_number }}
         run: |
           python setup.py sdist bdist_wheel
 

--- a/patches/setup.patch
+++ b/patches/setup.patch
@@ -1,8 +1,28 @@
 diff --git a/setup.py b/setup.py
-index 2c80ffa..28331a3 100644
+index 2c80ffa..1ed1d74 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -23,22 +23,23 @@ with open('requirements.txt') as handle:
+@@ -3,6 +3,7 @@
+ """
+ Install PlexAPI
+ """
++import os
+ from pkg_resources import parse_requirements
+ try:
+     from setuptools import setup
+@@ -14,6 +15,11 @@ version = {}
+ with open('plexapi/const.py') as handle:
+     exec(handle.read(), version)
+ 
++try:
++    version['__version__'] += "-{}".format(os.environ['BUILD_NUMBER'])
++except KeyError:
++    pass
++
+ # Get README.rst contents
+ with open('README.rst') as handle:
+     readme = handle.read()
+@@ -23,22 +29,23 @@ with open('requirements.txt') as handle:
      requirements = [str(req) for req in parse_requirements(handle)]
  
  setup(


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Add build number to pypi builds to allow uploading new/fixed builds.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
