### PR TITLE
build(pypi): revert filename change for wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,16 +242,15 @@ jobs:
 
           pypi_version=$(python setup.py --version)
 
-          # upload fails if using `-` instead of `_` even though that is in the original name...
-          # https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode
-
           # rename wheel
           mv dist/PlexAPI_backport-${pypi_version}-py2-none-any.whl \
-            dist/plexapi_backport-${pypi_version}-${BUILD_VERSION}-py2-none-any.whl
+            dist/PlexAPI_backport-${pypi_version}-${BUILD_VERSION}-py2-none-any.whl
 
           # rename tar
           mv dist/PlexAPI-backport-${pypi_version}.tar.gz \
             dist/plexapi_backport-${pypi_version}-${BUILD_VERSION}.tar.gz
+          # upload fails if using `-` instead of `_` even though that is in the original name...
+          # https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode
 
           # list dist files
           echo "dist files:"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Revert filename change for wheel, as it fails due to missing metadata file.

```txt
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         Wheel 'plexapi_backport-4.15.4-272-py2-none-any.whl' does not contain  
         the required METADATA file: plexapi_backport-4.15.4.dist-info/METADATA
```


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
