### PR TITLE
feat(backport): automatically remove typehints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ jobs:
         with:
           python-version: '2.7'
 
+      - name: Set up Python 3
+        id: python3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          update-environment: false
+
       - name: Set up Python Dependencies
         run: |
           echo "Installing Requirements"
@@ -44,6 +51,15 @@ jobs:
 
           # install python requirements
           python -m pip install --upgrade -r requirements_dev.txt
+
+      - name: Set up Python 3 Dependencies
+        run: |
+          echo "Installing Requirements"
+          ${{ steps.python3.outputs.python-path }} --version
+          ${{ steps.python3.outputs.python-path }} -m pip install --upgrade pip setuptools wheel
+
+          # install python requirements
+          ${{ steps.python3.outputs.python-path }} -m pip install --upgrade -r requirements_dev.txt
 
       - name: Find python files
         id: find_files
@@ -83,7 +99,16 @@ jobs:
             # remove the temp file
             rm -f ${temp_file}
 
+            # strip type hints
+            echo "Stripping type hints from ${file}"
+            # this must run under Python 3 due to https://github.com/abarker/strip-hints/issues/5
+            # update path env with directory name of where python 3 installs
+            TEMP_PATH=$(${{ steps.python3.outputs.python-path }} -c "import sys, os; \
+              print(os.path.dirname(sys.executable))")
+            PATH="$TEMP_PATH:$PATH" strip-hints --inplace ${file}
+
             # apply custom LizardByte patches
+            echo "Applying custom patches to ${file}"
             python ../custom_patches.py ${file}
 
             echo "Applying autopep8 to ${file}"

--- a/patches/plexapi_mixins.patch
+++ b/patches/plexapi_mixins.patch
@@ -1,30 +1,17 @@
 diff --git a/plexapi/mixins.py b/plexapi/mixins.py
-index ea6a075..c0881f5 100644
+index efe09e1..80acc8c 100644
 --- a/plexapi/mixins.py
 +++ b/plexapi/mixins.py
-@@ -8,6 +8,7 @@ from plexapi import media, settings, utils
+@@ -8,6 +8,8 @@ from plexapi import media, settings, utils
  from plexapi.exceptions import BadRequest, NotFound
  from plexapi.utils import deprecated, openOrRead
  
 +from backports.datetime_timestamp import timestamp
++
  
  class AdvancedSettingsMixin:
      """ Mixin for Plex objects that can have advanced settings. """
-@@ -65,11 +66,9 @@ class AdvancedSettingsMixin:
- class SmartFilterMixin:
-     """ Mixin for Plex objects that can have smart filters. """
- 
--    def _parseFilterGroups(
--        self, feed: "deque[Tuple[str, str]]", returnOn: "set[str]|None" = None
--    ) -> dict:
-+    def _parseFilterGroups(self, feed, returnOn = None):
-         """ Parse filter groups from input lines between push and pop. """
--        currentFiltersStack: list[dict] = []
-+        currentFiltersStack = []
-         operatorForStack = None
-         if returnOn is None:
-             returnOn = set("pop")
-@@ -563,9 +562,9 @@ class AddedAtMixin(EditFieldMixin):
+@@ -564,9 +566,9 @@ class AddedAtMixin(EditFieldMixin):
                  locked (bool): True (default) to lock the field, False to unlock the field.
          """
          if isinstance(addedAt, str):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,6 +5,7 @@
 # these are for backporting the project, not needed for tests
 autopep8==1.5.7;python_version<"3"
 future-fstrings==1.2.0;python_version<"3"
+strip-hints==0.1.10;python_version>"3"  # must run in python 3 due to https://github.com/abarker/strip-hints/issues/5
 
 # this is needed for linting tests only
 flake8==3.9.2;python_version<"3"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Automatically remove typehints.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
