### PR TITLE
fix(backport): automatically remove trailing commas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           python -m pip --no-python-version-warning --disable-pip-version-check install --upgrade pip setuptools wheel
 
           # install python requirements
+          python -m pip install --upgrade -r requirements_ci.txt
           python -m pip install --upgrade -r requirements_dev.txt
 
       - name: Set up Python 3 Dependencies
@@ -59,7 +60,7 @@ jobs:
           ${{ steps.python3.outputs.python-path }} -m pip install --upgrade pip setuptools wheel
 
           # install python requirements
-          ${{ steps.python3.outputs.python-path }} -m pip install --upgrade -r requirements_dev.txt
+          ${{ steps.python3.outputs.python-path }} -m pip install --upgrade -r requirements_ci.txt
 
       - name: Find python files
         id: find_files

--- a/custom_patches.py
+++ b/custom_patches.py
@@ -242,6 +242,44 @@ def raise_from_none_patch(lines):
     return lines
 
 
+def remove_trailing_commas(lines):
+    """
+    Remove the trailing comma from the last argument in function definitions.
+    Handles cases for both single line and multiline definitions.
+
+    Parameters
+    ----------
+    lines : List[str]
+        The lines of the file.
+
+    Returns
+    -------
+    List[str]
+        Updated lines.
+    """
+    for i in range(len(lines) - 1):
+        line = lines[i].rstrip()
+        next_line = lines[i + 1].strip()
+
+        # Handle single line function definition with trailing comma
+        if line.startswith('def ') and ',):' in line:
+            lines[i] = line.replace(',):', '):') + '\n'
+
+        # Handle multiline function definitions
+        elif line.endswith(',') and (next_line == ')' or next_line.startswith(')')):
+            lines[i] = line[:-1] + '\n'
+        elif ',):' in line:
+            # Handle cases where the function arguments end on the same line as the closing parenthesis
+            lines[i] = line.replace(',):', '):') + '\n'
+
+    # Check the last line separately
+    last_line = lines[-1].rstrip()
+    if last_line.endswith(',):'):
+        lines[-1] = last_line.replace(',):', '):') + '\n'
+
+    return lines
+
+
 def shutil_which_patch(lines):
     # type: (List[str]) -> List[str]
     """
@@ -449,6 +487,7 @@ def process_file(file_path):
 
     lines = arg_unpack_patch(lines=lines)
     lines = raise_from_none_patch(lines=lines)
+    lines = remove_trailing_commas(lines=lines)
     lines = super_patch(lines=lines)
     lines = urllib_imports_patch(lines=lines)
     lines = yield_from_patch(lines=lines)

--- a/custom_patches.py
+++ b/custom_patches.py
@@ -244,8 +244,7 @@ def raise_from_none_patch(lines):
 
 def remove_trailing_commas(lines):
     """
-    Remove the trailing comma from the last argument in function definitions.
-    Handles cases for both single line and multiline definitions.
+    Remove the trailing comma from function definitions, when there is a trailing comma after **kwargs.
 
     Parameters
     ----------
@@ -261,21 +260,9 @@ def remove_trailing_commas(lines):
         line = lines[i].rstrip()
         next_line = lines[i + 1].strip()
 
-        # Handle single line function definition with trailing comma
-        if line.startswith('def ') and ',):' in line:
-            lines[i] = line.replace(',):', '):') + '\n'
-
         # Handle multiline function definitions
-        elif line.endswith(',') and (next_line == ')' or next_line.startswith(')')):
+        if line.endswith('**kwargs,') and next_line == '):':
             lines[i] = line[:-1] + '\n'
-        elif ',):' in line:
-            # Handle cases where the function arguments end on the same line as the closing parenthesis
-            lines[i] = line.replace(',):', '):') + '\n'
-
-    # Check the last line separately
-    last_line = lines[-1].rstrip()
-    if last_line.endswith(',):'):
-        lines[-1] = last_line.replace(',):', '):') + '\n'
 
     return lines
 

--- a/requirements_ci.txt
+++ b/requirements_ci.txt
@@ -1,0 +1,4 @@
+# these are for backporting the project, not needed for tests
+autopep8==1.5.7;python_version<"3"
+future-fstrings==1.2.0;python_version<"3"
+strip-hints==0.1.10;python_version>"3"  # must run in python 3 due to https://github.com/abarker/strip-hints/issues/5

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,10 +2,6 @@
 -r requirements.txt
 # python 2.7
 # everything is specifically marked as python_version<"3" because we merge it to the existing requirements_dev.txt
-# these are for backporting the project, not needed for tests
-autopep8==1.5.7;python_version<"3"
-future-fstrings==1.2.0;python_version<"3"
-strip-hints==0.1.10;python_version>"3"  # must run in python 3 due to https://github.com/abarker/strip-hints/issues/5
 
 # this is needed for linting tests only
 flake8==3.9.2;python_version<"3"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Remove trailing commas automatically.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
